### PR TITLE
trap exceptions rather than try/catch

### DIFF
--- a/Install/chocolateyInstall.ps1
+++ b/Install/chocolateyInstall.ps1
@@ -12,12 +12,10 @@ if (-not (Test-Path $ModuleRoot)) {
   New-Item -Type directory $ModuleRoot
 }
 $ModuleTarget = Join-Path $env:chocolateyPackageFolder "Modules"
-Get-ChildItem $ModuleTarget | Foreach-Object {
-  if (Test-Path "$ModuleRoot\$_") {
-    cmd /c rmdir "$ModuleRoot\$_"
-  }
-  cmd /c mklink /j "$ModuleRoot\$_" "$ModuleTarget\$_"
-  Get-ChildItem -Path "$ModuleRoot\$_" -File -Recurse | Unblock-File
+if (Test-Path "$ModuleRoot\Invoke-MSBuild") {
+  cmd /c rmdir "$ModuleRoot\Invoke-MSBuild"
 }
+cmd /c mklink /j "$ModuleRoot\Invoke-MSBuild" "$ModuleTarget\Invoke-MSBuild"
+Get-ChildItem -Path "$ModuleRoot\$_" -File -Recurse | Unblock-File
 
 Write-ChocolateySuccess 'Invoke-MSBuild'

--- a/Install/chocolateyInstall.ps1
+++ b/Install/chocolateyInstall.ps1
@@ -3,10 +3,12 @@ trap {
   Throw $_
 }
 
-$params = ConvertFrom-StringData -StringData ($env:chocolateyPackageParameters -replace ';', "`n")
+$params = ConvertFrom-StringData ($env:chocolateyPackageParameters -replace ';', "`n")
 
-$ModuleRoot = if ($params.PSModuleDirectory) { $params.PSModuleDirectory }
-  else { Join-Path $env:USERPROFILE "Documents\WindowsPowerShell\Modules" }
+$ModuleRoot = $params.PSModuleDirectory
+if (-not $ModuleRoot) {
+  $ModuleRoot = Join-Path $env:USERPROFILE "Documents\WindowsPowerShell\Modules"
+}
 
 if (-not (Test-Path $ModuleRoot)) {
   New-Item -Type directory $ModuleRoot

--- a/Install/chocolateyInstall.ps1
+++ b/Install/chocolateyInstall.ps1
@@ -6,7 +6,7 @@ trap {
 $params = ConvertFrom-StringData -StringData ($env:chocolateyPackageParameters -replace ';', "`n")
 
 $ModuleRoot = if ($params.PSModuleDirectory) { $params.PSModuleDirectory }
-  else { Join-Path $HOME "Documents\WindowsPowerShell\Modules" }
+  else { Join-Path $env:USERPROFILE "Documents\WindowsPowerShell\Modules" }
 
 if (-not (Test-Path $ModuleRoot)) {
   New-Item -Type directory $ModuleRoot

--- a/Install/chocolateyInstall.ps1
+++ b/Install/chocolateyInstall.ps1
@@ -1,25 +1,23 @@
-try
-{
-	$params = ConvertFrom-StringData -StringData ($env:chocolateyPackageParameters -replace ';', "`n")
-
-	$ModuleRoot = if ($params.PSModuleDirectory) { $params.PSModuleDirectory }
-		else { Join-Path $HOME "Documents\WindowsPowerShell\Modules" }
-
-	if (-not (Test-Path $ModuleRoot)) {
-		New-Item -Type directory $ModuleRoot
-	}
-	$ModuleTarget = Join-Path $env:chocolateyPackageFolder "Modules"
-	Get-ChildItem $ModuleTarget | Foreach-Object {
-		if (Test-Path "$ModuleRoot\$_") {
-			cmd /c rmdir "$ModuleRoot\$_"
-		}
-		cmd /c mklink /j "$ModuleRoot\$_" "$ModuleTarget\$_"
-		Get-ChildItem -Path "$ModuleRoot\$_" -File -Recurse | Unblock-File
-	}
-
-	Write-ChocolateySuccess 'Invoke-MSBuild'
-} catch {
-	Write-ChocolateyFailure 'Invoke-MSBuild' $($_.Exception.Message)
-	$host.SetShouldExit(1)
-	throw $_
+trap {
+  Write-ChocolateyFailure 'Invoke-MSBuild' $($_.Exception.Message)
+  Throw $_
 }
+
+$params = ConvertFrom-StringData -StringData ($env:chocolateyPackageParameters -replace ';', "`n")
+
+$ModuleRoot = if ($params.PSModuleDirectory) { $params.PSModuleDirectory }
+  else { Join-Path $HOME "Documents\WindowsPowerShell\Modules" }
+
+if (-not (Test-Path $ModuleRoot)) {
+  New-Item -Type directory $ModuleRoot
+}
+$ModuleTarget = Join-Path $env:chocolateyPackageFolder "Modules"
+Get-ChildItem $ModuleTarget | Foreach-Object {
+  if (Test-Path "$ModuleRoot\$_") {
+    cmd /c rmdir "$ModuleRoot\$_"
+  }
+  cmd /c mklink /j "$ModuleRoot\$_" "$ModuleTarget\$_"
+  Get-ChildItem -Path "$ModuleRoot\$_" -File -Recurse | Unblock-File
+}
+
+Write-ChocolateySuccess 'Invoke-MSBuild'


### PR DESCRIPTION
It is more robust to have a catch all (in the form of a trap) to catch exceptions and send an error to chocolatey. Also, the force quit is no longer required after v0.9.8.32 (see https://github.com/chocolatey/chocolatey/issues/568 for more info).
